### PR TITLE
Completed Edge Permutations

### DIFF
--- a/BackEnd/DataStructures/EdgeCombinations.swift
+++ b/BackEnd/DataStructures/EdgeCombinations.swift
@@ -5,7 +5,9 @@
 //  Created by Brandon Wong on 3/21/19.
 //
 
-func edgeComb(n: Int, k: Int) -> [[String]] {
+func edgeComb(locations: [String]) -> [[String]] {
+    let n = locations.count
+    let k = 2
     var edges = [[Int]]()
     var result = [[String]]()
     
@@ -31,6 +33,6 @@ func edgeComb(n: Int, k: Int) -> [[String]] {
     return result
 }
 let locations = ["Aiea", "Manoa", "Kalihi", "Ewa", "Honolulu"]
-let edges = edgeComb(n: locations.count, k: 2)
+let edges = edgeComb(locations: locations)
 print(locations)
 print(edges)

--- a/BackEnd/DataStructures/EdgeCombinations.swift
+++ b/BackEnd/DataStructures/EdgeCombinations.swift
@@ -1,0 +1,36 @@
+//
+//  EdgeCombinations.swift
+//  
+//
+//  Created by Brandon Wong on 3/21/19.
+//
+
+func edgeComb(n: Int, k: Int) -> [[String]] {
+    var edges = [[Int]]()
+    var result = [[String]]()
+    
+    func combinations(offset: Int, partial: [Int]) {
+        if partial.count == k {
+            edges.append(partial)
+            return
+        }
+        
+        let numRemaining = k - partial.count
+        var i = offset
+        while i <= n && numRemaining <= n - i + 1 {
+            combinations(offset: i + 1, partial: partial + [i])
+            i += 1
+        }
+    }
+    
+    combinations(offset: 1, partial: [Int]())
+    for edge in edges {
+        result.append([locations[edge[0] - 1], locations[edge[1] - 1]])
+        result.append([locations[edge[1] - 1], locations[edge[0] - 1]])
+    }
+    return result
+}
+let locations = ["Aiea", "Manoa", "Kalihi", "Ewa", "Honolulu"]
+let edges = edgeComb(n: locations.count, k: 2)
+print(locations)
+print(edges)

--- a/TestPlayground.playground/Contents.swift
+++ b/TestPlayground.playground/Contents.swift
@@ -1,4 +1,6 @@
-func edgeComb(n: Int, k: Int) -> [[String]] {
+func edgeComb(locations: [String]) -> [[String]] {
+    let n = locations.count
+    let k = 2
     var edges = [[Int]]()
     var result = [[String]]()
     
@@ -24,6 +26,6 @@ func edgeComb(n: Int, k: Int) -> [[String]] {
     return result
 }
 let locations = ["Aiea", "Manoa", "Kalihi", "Ewa", "Honolulu"]
-let edges = edgeComb(n: locations.count, k: 2)
+let edges = edgeComb(locations: locations)
 print(locations)
 print(edges)

--- a/TestPlayground.playground/Contents.swift
+++ b/TestPlayground.playground/Contents.swift
@@ -1,0 +1,29 @@
+func edgeComb(n: Int, k: Int) -> [[String]] {
+    var edges = [[Int]]()
+    var result = [[String]]()
+    
+    func combinations(offset: Int, partial: [Int]) {
+        if partial.count == k {
+            edges.append(partial)
+            return
+        }
+        
+        let numRemaining = k - partial.count
+        var i = offset
+        while i <= n && numRemaining <= n - i + 1 {
+            combinations(offset: i + 1, partial: partial + [i])
+            i += 1
+        }
+    }
+    
+    combinations(offset: 1, partial: [Int]())
+    for edge in edges {
+        result.append([locations[edge[0] - 1], locations[edge[1] - 1]])
+        result.append([locations[edge[1] - 1], locations[edge[0] - 1]])
+    }
+    return result
+}
+let locations = ["Aiea", "Manoa", "Kalihi", "Ewa", "Honolulu"]
+let edges = edgeComb(n: locations.count, k: 2)
+print(locations)
+print(edges)

--- a/TestPlayground.playground/contents.xcplayground
+++ b/TestPlayground.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' executeOnSourceChanges='false'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>


### PR DESCRIPTION
This function takes in an array of `Strings` representing address locations from the UI. It then outputs a permutation of each edge between pair of graph vertices. Take note that the commute time from an origin to destination will be different if we reverse the order of origin and destination locations. 

This function will serve mainly for properly computing the edge weights from Ryuto's implementation. Please let me know your thoughts on my PR. 

Note: The Playground file is simply just a way of testing functions during development before transferring it over to a formal `.Swift` file. 